### PR TITLE
Set hostname-for-clients same as client-bind-address

### DIFF
--- a/cluster/bin/snappy
+++ b/cluster/bin/snappy
@@ -108,6 +108,13 @@ elif [ -z "$SNAPPY_NO_QUICK_LAUNCH" -a $# -ge 2 \
         fi
       elif [ -n "$IMPLICIT_CLIENT_BIND_ADDRESS" ]; then
         IMPLICIT_AWS_CLIENT_BIND_ADDRESS="-client-bind-address=${IMPLICIT_CLIENT_BIND_ADDRESS}"
+        if [ -z "$SPARK_PUBLIC_DNS" ]; then
+          HOSTNAME_FOR_CLIENTS="-hostname-for-clients=${IMPLICIT_CLIENT_BIND_ADDRESS}"
+          export SPARK_PUBLIC_DNS="${IMPLICIT_CLIENT_BIND_ADDRESS}"
+        fi
+      elif [ -n "$EXPLICIT_CLIENT_BIND_ADDRESS" -a -z "$SPARK_PUBLIC_DNS" ]; then
+        HOSTNAME_FOR_CLIENTS="-hostname-for-clients=${EXPLICIT_CLIENT_BIND_ADDRESS}"
+        export SPARK_PUBLIC_DNS="${EXPLICIT_CLIENT_BIND_ADDRESS}"
       fi
     fi
   fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -200,9 +200,14 @@ function execute() {
     preCommand="${preCommand}export SPARK_LOCAL_IP=$bindAddress; "
 
     # set the default client-bind-address and locator's peer-discovery-address
-    if [ -z "${clientBindAddress}" -a "${componentType}" != "lead" ]; then
-      preCommand="${preCommand}export IMPLICIT_CLIENT_BIND_ADDRESS=$host; "
-      export IMPLICIT_CLIENT_BIND_ADDRESS="${host}"
+    if [ "${componentType}" != "lead" ]; then
+      if [ -z "${clientBindAddress}" ]; then
+        preCommand="${preCommand}export IMPLICIT_CLIENT_BIND_ADDRESS=$host; "
+        export IMPLICIT_CLIENT_BIND_ADDRESS="${host}"
+      else
+        preCommand="${preCommand}export EXPLICIT_CLIENT_BIND_ADDRESS=$clientBindAddress; "
+        export EXPLICIT_CLIENT_BIND_ADDRESS="${clientBindAddress}"
+      fi
     fi
     if [ -z "$(echo $args $"${@// /\\ }" | grep 'peer-discovery-address=')" -a "${componentType}" = "locator" ]; then
       args="${args} -peer-discovery-address=${host}"


### PR DESCRIPTION
if hostname-for-clients has not been explicitly specified then set it the same as client-bind-address (which itself gets set to the specified host if not explicitly given).