### PR TITLE
 [SNAP-3332] set scale/precision array on session in each PreparedStatement execution

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/ClusterCallbacksImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/ClusterCallbacksImpl.scala
@@ -17,11 +17,9 @@
 package io.snappydata.gemxd
 
 import java.io.{File, InputStream}
+import java.util.{Iterator => JIterator}
 import java.{lang, util}
-import java.util.{List, Iterator => JIterator}
 
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Try
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
@@ -41,12 +39,12 @@ import io.snappydata.recovery.RecoveryService
 import io.snappydata.remote.interpreter.SnappyInterpreterExecute
 import io.snappydata.{ServiceManager, SnappyEmbeddedTableStatsProviderService}
 
-import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.Logging
 import org.apache.spark.scheduler.cluster.SnappyClusterManager
 import org.apache.spark.serializer.{KryoSerializerPool, StructTypeSerializer}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.collection.ToolsCallbackInit
-import org.apache.spark.sql.{Row, SaveMode, SnappyContext}
+import org.apache.spark.sql.{SaveMode, SnappyContext}
 
 /**
  * Callbacks that are sent by GemXD to Snappy for cluster management
@@ -96,11 +94,11 @@ object ClusterCallbacksImpl extends ClusterCallbacks with Logging {
 
   override def getSQLExecute(df: AnyRef, sql: String, schema: String, ctx: LeadNodeExecutionContext,
       v: Version, isPreparedStatement: Boolean, isPreparedPhase: Boolean,
-      pvs: ParameterValueSet): SparkSQLExecute = {
+      pvs: ParameterValueSet, pvsTypes: Array[Int]): SparkSQLExecute = {
     if (isPreparedStatement && isPreparedPhase) {
       new SparkSQLPrepareImpl(sql, schema, ctx, v)
     } else {
-      new SparkSQLExecuteImpl(df, sql, schema, ctx, v, Option(pvs))
+      new SparkSQLExecuteImpl(df, sql, schema, ctx, v, Option(pvs), pvsTypes)
     }
   }
 

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -58,7 +58,8 @@ class SparkSQLExecuteImpl(
     val schema: String,
     val ctx: LeadNodeExecutionContext,
     senderVersion: Version,
-    pvs: Option[ParameterValueSet]) extends SparkSQLExecute with Logging {
+    pvs: Option[ParameterValueSet],
+    pvsTypes: Array[Int]) extends SparkSQLExecute with Logging {
 
   // spark context will be constructed by now as this will be invoked when
   // DRDA queries will reach the lead node
@@ -80,6 +81,7 @@ class SparkSQLExecuteImpl(
   Utils.setCurrentSchema(session, schema, createIfNotExists = true)
 
   session.setPreparedQuery(preparePhase = false, pvs)
+  session.setPreparedParamsTypeInfo(pvsTypes)
 
   session.sessionState.jdbcQueryJobGroupId = Option(ctx.getStatementId.toString)
 

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
@@ -115,17 +115,16 @@ class SparkSQLPrepareImpl(val sql: String,
       if (paramCount != questionMarkCounter) {
         throw Util.generateCsSQLException(SQLState.NOT_FOR_PREPARED_STATEMENT, sql)
       }
-      val types = new Array[Int](paramCount * 4 + 1)
+      val types = new Array[Int](paramCount * 3 + 1)
       types(0) = paramCount
       (0 until paramCount) foreach (i => {
         assert(paramLiteralsAtPrepare(i).pos == i + 1)
-        val index = i * 4 + 1
+        val index = i * 3 + 1
         val dType = paramLiteralsAtPrepare(i).dataType
         val sqlType = getSQLType(dType)
         types(index) = sqlType._1
         types(index + 1) = sqlType._2
         types(index + 2) = sqlType._3
-        types(index + 3) = if (paramLiteralsAtPrepare(i).value.asInstanceOf[Boolean]) 1 else 0
       })
       session.setPreparedParamsTypeInfo(types)
       DataSerializer.writeIntArray(types, hdos)

--- a/core/src/main/scala/org/apache/spark/jdbc/ConnectionConf.scala
+++ b/core/src/main/scala/org/apache/spark/jdbc/ConnectionConf.scala
@@ -135,7 +135,7 @@ class ConnectionConfBuilder(session: SnappySession) {
       connSettings.put("poolProperties", poolProperties)
     }
 
-    val connProps = ExternalStoreUtils.validateAndGetAllProps(Some(session),
+    val connProps = ExternalStoreUtils.validateAndGetAllProps(Option(session),
       new CaseInsensitiveMutableHashMap(connSettings))
     new ConnectionConf(connProps)
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2164,7 +2164,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
         // try to normalize parameter value into target column's scale/precision
         val index = (questionMarkCounter - 1) * 4 + 1
         // actual scale of the target column
-        val scale = preparedParamsTypesInfo.map(a => a(index + 2)).getOrElse(-1)
+        val scale = preparedParamsTypesInfo.map(a => a(index + 2)).getOrElse(0)
 
         val decimalValue = new com.pivotal.gemfirexd.internal.iapi.types.SQLDecimal()
         val typeId = TypeId.getBuiltInTypeId(java.sql.Types.DECIMAL)

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2162,7 +2162,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     val (storePrecision, storeScale) = dvd match {
       case _: stypes.SQLDecimal =>
         // try to normalize parameter value into target column's scale/precision
-        val index = (questionMarkCounter - 1) * 4 + 1
+        val index = (questionMarkCounter - 1) * 3 + 1
         // actual scale of the target column
         val scale = preparedParamsTypesInfo.map(a => a(index + 2)).getOrElse(0)
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -320,8 +320,12 @@ object ExternalStoreUtils {
         true
       case SnappyStoreClientDialect =>
         SnappyStoreClientDialect.addExtraDriverProperties(isLoner, connProps)
-        connProps.setProperty(ClientAttribute.ROUTE_QUERY, "false")
-        executorConnProps.setProperty(ClientAttribute.ROUTE_QUERY, "false")
+        val routeQuery = parameters.get(ClientAttribute.ROUTE_QUERY) match {
+          case Some(v) => v
+          case None => "false"
+        }
+        connProps.setProperty(ClientAttribute.ROUTE_QUERY, routeQuery)
+        executorConnProps.setProperty(ClientAttribute.ROUTE_QUERY, routeQuery)
         // increase the lob-chunk-size to match/exceed column batch size
         val batchSize = parameters.get(COLUMN_BATCH_SIZE) match {
           case Some(s) => sizeAsBytes(s, COLUMN_BATCH_SIZE)


### PR DESCRIPTION
The prepare phase of PreparedStatement returns the scale/precision of parameters for routed
queries. This should be set back on SnappySession during execution so that the current set
of parameters are used rather than those set by the last prepare (which can be different)

Also made the PVS info array size uniform to be three ints per type removing the unused
(and incorrect) fourth field which is supposed to have nullability information.

Added unit test for the bug (PreparedQueryRoutingSingleNodeSuite.scala#SNAP-3332)

## Other PRs 

https://github.com/TIBCOSoftware/snappy-store/pull/567