### PR TITLE
Column compaction; cleanup snapshot transactions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ allprojects {
     janinoVersion = '3.0.8'
     derbyVersion = '10.14.2.0'
     parboiledVersion = '2.1.8'
-    tomcatJdbcVersion = '8.5.37'
+    tomcatJdbcVersion = '10.0.10'
     hikariCPVersion = '2.7.9'
     twitter4jVersion = '4.0.7'
     objenesisVersion = '3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ allprojects {
     sparkJobServerVersion = '0.6.2.12'
     snappySparkMetricsLibVersion = '2.0.0.1'
     log4jVersion = '1.2.17'
-    slf4jVersion = '1.7.25'
+    slf4jVersion = '1.7.30'
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'
     hadoopVersion = '3.2.0'

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -220,6 +220,8 @@ class SplitSnappyClusterDUnitTest(s: String)
     Assert.assertEquals(10000100, stats1.getRowCount)
     vm1.invoke(restartServer)
 
+    Thread.sleep(10000) // allow pool connections to be checked for validity
+
     // Test using using 5 buckets
     vm3.invoke(getClass, "checkStatsForSplitMode", startArgs :+
         "8" :+ Int.box(locatorClientPort))

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -439,6 +439,7 @@ object ValidateMVCCDUnitTest {
 
     val tableName: String = "APP.TESTTABLE"
     val conn = DriverManager.getConnection(url)
+    conn.setTransactionIsolation(IsolationLevel.SNAPSHOT_JDBC_LEVEL)
 
     val s = conn.createStatement()
     s.execute(s"select * from $tableName")
@@ -506,6 +507,7 @@ object ValidateMVCCDUnitTest {
     cache.waitOnRvvTestHook()
     cache.setRvvSnapshotTestHook(null)
 
+    conn.commit()
 
     var cnt4 = 0
     s.execute(s"select * from " +
@@ -549,6 +551,8 @@ object ValidateMVCCDUnitTest {
     // scalastyle:on
     assert(cnt6 >= 9, s"Expected row count is 10 while actual row count is $cnt6")
 
+    conn.commit()
+    conn.close()
   }
 
 
@@ -566,7 +570,7 @@ object ValidateMVCCDUnitTest {
 
     val tableName: String = "APP.TESTTABLE"
     val conn = DriverManager.getConnection(url)
-
+    conn.setTransactionIsolation(IsolationLevel.SNAPSHOT_JDBC_LEVEL)
 
     val s = conn.createStatement()
     s.execute(s"select * from $tableName")
@@ -584,6 +588,7 @@ object ValidateMVCCDUnitTest {
     // scalastyle:on
     assert(cnt >= 9, s"Expected row count is 10 while actual row count is $cnt")
 
+    conn.commit()
 
     var cnt1 = 0
     s.execute(s"select * from $tableName -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
@@ -625,6 +630,7 @@ object ValidateMVCCDUnitTest {
     // scalastyle:on
     assert(cnt3 >= 9, s"Expected row count is 10 while actual row count is $cnt3")
 
+    conn.commit()
 
     // The number of entries in column store is 4 as after
     // columnwise storage 3 rows will be created one for each
@@ -645,6 +651,9 @@ object ValidateMVCCDUnitTest {
       // scalastyle:on
       cnt4 == 0
     }, "Row count not 0 even after rollback ", 30000, 500, true)
+
+    conn.commit()
+    conn.close()
   }
 
   def performBatchInsert(netPort: Int): Unit = {

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -588,8 +588,6 @@ object ValidateMVCCDUnitTest {
     // scalastyle:on
     assert(cnt >= 9, s"Expected row count is 10 while actual row count is $cnt")
 
-    conn.commit()
-
     var cnt1 = 0
     s.execute(s"select * from $tableName -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
     val rs1 = s.getResultSet
@@ -654,6 +652,8 @@ object ValidateMVCCDUnitTest {
 
     conn.commit()
     conn.close()
+
+    cache.getCacheTransactionManager.testRollBack = false
   }
 
   def performBatchInsert(netPort: Int): Unit = {

--- a/cluster/src/dunit/scala/org/apache/spark/sql/ColumnBatchAndExternalTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/ColumnBatchAndExternalTableDUnitTest.scala
@@ -402,13 +402,13 @@ class ColumnBatchAndExternalTableDUnitTest(s: String) extends ClusterManagerTest
   private def assertMaxTasksStarted(max: Int, expected: Int): Unit = {
     // occasionally a few tasks more than expected might get started due to gap between
     // notification and job submissions
-    assert(max - expected <= TestUtils.defaultCores / 2,
+    assert(max - expected <= TestUtils.defaultCores,
       s"Upper limit of concurrent tasks = $expected, actual = $max")
   }
 
   private def assertMinTasksStarted(max: Int, expected: Int): Unit = {
     // lower limit might get violated due to the gap between notification and job submissions
-    assert(expected - max <= TestUtils.defaultCores / 2,
+    assert(expected - max <= TestUtils.defaultCores,
       s"Lower limit of concurrent tasks = $expected, actual = $max")
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/memory/MemoryFunSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/MemoryFunSuite.scala
@@ -24,11 +24,10 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{SnappyContext, SnappySession, SparkSession}
 
-class MemoryFunSuite extends SparkFunSuite with BeforeAndAfter with BeforeAndAfterAll {
+abstract class MemoryFunSuite extends SparkFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     System.clearProperty("snappydata.umm.memtrace")
-    return
   }
 
   override def beforeAll(): Unit = {

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -211,6 +211,7 @@ trait SplitClusterDUnitTestBase extends ClusterUtils with Logging {
           ColumnUpdateDeleteTests.testSNAP1926(session)
           ColumnUpdateDeleteTests.testConcurrentOps(session)
           ColumnUpdateDeleteTests.testSNAP2124(session)
+          ColumnUpdateDeleteTests.testConcurrentUpdateDeleteForCompaction(session)
         } finally {
           StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT = false
         }

--- a/core/src/dunit/scala/org/apache/spark/sql/streaming/SnappySinkProviderDUnitTest.scala
+++ b/core/src/dunit/scala/org/apache/spark/sql/streaming/SnappySinkProviderDUnitTest.scala
@@ -22,6 +22,7 @@ import java.sql.Connection
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.annotation.tailrec
 import scala.reflect.io.Path
 
 import com.pivotal.gemfirexd.Attribute
@@ -425,6 +426,7 @@ object SnappySinkProviderDUnitTest extends Logging {
         actualData.map(a => a.toString()).mkString(","))
   }
 
+  @tailrec
   private def waitTillTheBatchIsPickedForProcessing(batchId: Int, testId: String,
       retries: Int = 15): Unit = {
     if (retries == 0) {

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -145,6 +145,14 @@ object Property extends Enumeration {
         s"each table using the ${ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS} option in " +
         s"create table DDL else this setting is used for the create table.", Some(10000))
 
+  val ColumnCompactionRatio: SparkValue[Double] = Val[Double](
+    s"${Constant.PROPERTY_PREFIX}column.compactionRatio",
+    "Proportion of updated/deleted rows in a column batch after which the batch will be " +
+        "compacted. This should be a double value between 0 (exclusive) and 1 (inclusive). " +
+        "A value of 1 will disable compaction. This property has to be set at spark " +
+        "configuration level or as system property (latter on all the servers) and cannot be " +
+        "changed at the session level. Default is 0.1", Some(0.1))
+
   val DisableHashJoin: SQLValue[Boolean] = SQLVal[Boolean](
     s"${Constant.PROPERTY_PREFIX}sql.disableHashJoin",
     "Disable hash joins completely including those for replicated row tables. Default is false.",

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -908,12 +908,6 @@ object Utils extends Logging {
       case _ => false
     }
   }
-
-  override def logInfo(msg: => String): Unit = super.logInfo(msg)
-
-  override def logWarning(msg: => String): Unit = super.logWarning(msg)
-
-  override def logError(msg: => String): Unit = super.logError(msg)
 }
 
 class ExecutorLocalRDD[T: ClassTag](_sc: SparkContext, blockManagerIds: Seq[BlockManagerId],

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -253,7 +253,7 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
 
   override def nodeName: String = "ExecutePlan"
 
-  override def simpleString: String = "ExecutePlan"
+  override def simpleString: String = s"ExecutePlan(${child.simpleString})"
 
   private def collectRDD(sc: SparkContext, rdd: RDD[InternalRow]): Array[InternalRow] = {
     // direct RDD collect causes NPE in new Array due to (missing?) ClassTag for some reason
@@ -279,7 +279,8 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
       val (result, shuffleIds) = if (oldExecutionId eq null) {
         val (queryStringShortForm, queryStr, queryExecStr, planInfo) = if (key eq null) {
           val callSite = sqlContext.sparkContext.getCallSite()
-          (callSite.shortForm, callSite.longForm, treeString(verbose = true),
+          val prefix = simpleString + " from: "
+          (prefix + callSite.shortForm, prefix + callSite.longForm, treeString(verbose = true),
             PartitionedPhysicalScan.getSparkPlanInfo(this))
         } else {
           val paramLiterals = key.currentLiterals

--- a/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
@@ -76,7 +76,7 @@ object SecurityUtils extends Logging {
     if (Misc.isSecurityEnabled) {
       // pool connection is a proxy so get embedded connection
       val pooledConnection = ExternalStoreUtils.getConnection(rowBufferTable,
-        connProperties, forExecutor)
+        connProperties, forExecutor, resetIsolationLevel = true)
       val conn = pooledConnection.unwrap(classOf[EmbedConnection])
       val lcc = conn.getLanguageConnectionContext
       var popContext = false

--- a/core/src/main/scala/org/apache/spark/sql/execution/SnapshotConnectionListener.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SnapshotConnectionListener.scala
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2017-2021 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.execution
+
+import java.sql.Connection
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.{Consumer, Function}
+
+import scala.collection.JavaConverters._
+
+import com.gemstone.gemfire.SystemFailure
+import com.gemstone.gemfire.cache.IsolationLevel
+import com.gemstone.gemfire.internal.cache.BucketRegion.RolloverResult
+import com.gemstone.gemfire.internal.cache.{DiskStoreImpl, LocalRegion}
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures
+import com.pivotal.gemfirexd.internal.iapi.services.context.ContextService
+import com.pivotal.gemfirexd.internal.impl.jdbc.{EmbedConnection, EmbedConnectionContext}
+import io.snappydata.thrift.StatementAttrs
+import io.snappydata.thrift.internal.ClientConnection
+
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.ConnectionPool.SNAPSHOT_POOL_SUFFIX
+import org.apache.spark.sql.execution.SnapshotConnectionListener.{parseRolloverResult, trace, warn}
+import org.apache.spark.sql.execution.columnar.ConnectionType.ConnectionType
+import org.apache.spark.sql.execution.columnar.impl.JDBCSourceAsColumnarStore
+import org.apache.spark.sql.execution.columnar.{ConnectionType, ExternalStoreUtils}
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.sources.ConnectionProperties
+import org.apache.spark.util.{TaskCompletionListener, TaskFailureListener}
+import org.apache.spark.{Logging, TaskContext}
+
+/**
+ * This is a TaskContext listener (for both success and failure of the task) that handles startup,
+ * commit and rollback of snapshot transactions for the task. It also provides a common connection
+ * that can be shared by all plans executing in the task. In conjunction with the apply methods of
+ * the companion object, it ensures that only one instance of this listener is attached in a
+ * TaskContext which is automatically removed at the end of the task execution.
+ *
+ * This is the preferred way for all plans that need connections and/or snapshot transactions so
+ * that handling transaction start/commit for any level of plan nesting etc can be dealt with
+ * cleanly for the entire duration of the task. Additionally cases where an EXCHANGE gets inserted
+ * between two plans are also handled as expected where separate transactions and connections will
+ * be used for the two plans. Both generated code and non-generated code (including RDD.compute)
+ * should use the apply methods of the companion object to obtain an instance of the listener,
+ * then use its connection() method to obtain the connection.
+ *
+ * One of the overloads of the apply method also allows one to send a custom connection creator
+ * instead of using the default one, but it is also assumed to return SnappyData connection only
+ * (either embedded or thin) for snapshot transactions to work. Typical usage of custom creator
+ * is for smart connector RDDs to use direct URLs without load-balance to the preferred hosts
+ * for the buckets being targeted instead of the default creator that will always use the locator.
+ */
+class SnapshotConnectionListener private(private var startSnapshotTx: Boolean,
+    private val connectionType: ConnectionType, rowTable: String, connProps: ConnectionProperties,
+    private var delayRollover: Boolean, creator: Either[Long, () => (Connection, Long)])
+    extends TaskCompletionListener with TaskFailureListener {
+
+  private[this] var conn: Connection = _
+  private[this] var catalogVersion: Long = -1
+  private[this] var lockedDiskStores: List[DiskStoreImpl] = Nil
+  private[this] var compactionMetric: Option[SQLMetric] = None
+  private[this] var rolloverMetric: Option[SQLMetric] = None
+  private[this] val isTransactionalPool = startSnapshotTx
+  private[this] var isSuccess = true
+
+  @inline
+  private def isInitialized: Boolean = conn ne null
+
+  private def initialize(): Unit = {
+    if (isInitialized) {
+      throw new IllegalStateException("SnapshotConnectionListener already initialized")
+    }
+    creator match {
+      case Left(version) =>
+        catalogVersion = version
+        beginSnapshotTx()
+      case Right(f) =>
+        val result = f()
+        conn = result._1
+        catalogVersion = result._2
+        beginSnapshotTx()
+        // custom creator may not have applied the catalogVersion and delayRollover attributes
+        if (!startSnapshotTx) applyTransientAttributes()
+    }
+  }
+
+  override def onTaskCompletion(context: TaskContext): Unit = {
+    try {
+      if (!isInitialized) return
+      if (connectionType != ConnectionType.Embedded) {
+        conn.unwrap(classOf[ClientConnection]).clearCommonStatementAttributes()
+      }
+      if (success()) {
+        val results = commitSnapshotTx()
+        // both local and remote node rollovers/compactions will be in the before-commit results
+        rolloverMetric match {
+          case Some(metric) =>
+            val numRollovers = results match {
+              case Left(beforeCommitResults) =>
+                if (beforeCommitResults.isEmpty) 0
+                else beforeCommitResults.asScala.foldLeft(0) {
+                  case (s, r: RolloverResult) if r.numKeysRolledOver > 0 => s + 1
+                  case (s, _) => s
+                }
+              case Right(str) =>
+                if (str.isEmpty) 0
+                else parseRolloverResult.findAllIn(str).size
+            }
+            metric.add(numRollovers)
+          case _ =>
+        }
+        /*
+        compactionMetric match {
+          case Some(metric) =>
+            val numCompacted = results match {
+              case Left(beforeCommitResults) =>
+                if (beforeCommitResults.isEmpty) 0
+                else beforeCommitResults.asScala.foldLeft(0) {
+                  case (s, CompactionResult(_, _, true)) => s + 1
+                  case (s, _) => s
+                }
+              case Right(str) =>
+                if (str.isEmpty) 0
+                else parseCompactionResult.findAllIn(str).size
+            }
+            metric.add(numCompacted)
+          case _ =>
+        }
+        */
+      } else {
+        rollbackSnapshotTx()
+      }
+    } finally {
+      SnapshotConnectionListener.clearContext(context, this)
+      try {
+        if (lockedDiskStores.nonEmpty) {
+          lockedDiskStores.foreach(_.releaseDiskStoreReadLock())
+        }
+        // reset isolation level for non-transactional pool connections
+        if ((conn ne null) && !isTransactionalPool && startSnapshotTx && !conn.isClosed) {
+          trace(s"Resetting isolation level for table $rowTable with $conn")
+          conn.setTransactionIsolation(Connection.TRANSACTION_NONE)
+        }
+      } finally {
+        if (conn ne null) conn.close()
+      }
+    }
+  }
+
+  override def onTaskFailure(context: TaskContext, error: Throwable): Unit = {
+    isSuccess = false
+    // trying to log when JVM is failing will cause trouble
+    if (!SystemFailure.isJVMFailureError(error)) {
+      warn(s"Going to rollback active transaction on $conn", error)
+    }
+  }
+
+  private def doLockDiskStore(tableName: String): Unit = {
+    // TODO: SW: lock disk store in Net mode too using a statement attribute through this
+    // but existing locking does not seem correct since the bucket primary might be a remote node
+    if (connectionType == ConnectionType.Embedded) {
+      val rgn = Misc.getRegionForTable(tableName, false)
+      if (rgn ne null) {
+        val ds = rgn.asInstanceOf[LocalRegion].getDiskStore
+        if (ds ne null) {
+          if (!lockedDiskStores.contains(ds)) {
+            ds.acquireDiskStoreReadLock()
+            lockedDiskStores = ds :: lockedDiskStores
+          }
+        }
+      }
+    }
+  }
+
+  // begin should decide the connection which will be used by insert/commit/rollback
+  private def beginSnapshotTx(): Unit = {
+    val initialized = isInitialized
+    if (!initialized) {
+      val poolId = if (isTransactionalPool) rowTable + SNAPSHOT_POOL_SUFFIX else rowTable
+      conn = ExternalStoreUtils.getConnection(poolId, connProps,
+        forExecutor = true, resetIsolationLevel = false)
+    }
+    assert(!conn.isClosed)
+    if (!startSnapshotTx) return
+
+    trace(s"Going to start snapshot transaction for table $rowTable with $conn")
+    conn.setTransactionIsolation(IsolationLevel.SNAPSHOT_JDBC_LEVEL)
+    if (conn.getAutoCommit) conn.setAutoCommit(false)
+    applyTransientAttributes()
+    trace(s"Started snapshot transaction for table $rowTable")
+  }
+
+  private def commitSnapshotTx(): Either[java.util.List[AnyRef], String] = {
+    if (!startSnapshotTx && conn.getTransactionIsolation == Connection.TRANSACTION_NONE) {
+      return Left(java.util.Collections.emptyList[AnyRef])
+    }
+
+    var success = false
+    var failure: Throwable = null
+    try {
+      trace(s"Going to commit active transaction on $conn")
+      connectionType match {
+        case ConnectionType.Embedded =>
+          val beforeCommitResults = GfxdSystemProcedures.commitTransaction(
+            conn.unwrap(classOf[EmbedConnection]))
+          success = true
+          Left(beforeCommitResults)
+        case _ =>
+          conn.commit()
+          success = true
+          Right(conn.unwrap(classOf[ClientConnection]).getLastCommitResults)
+      }
+    } catch {
+      case t: Throwable if !SystemFailure.isJVMFailureError(t) => failure = t; throw t
+    } finally {
+      if (!success) {
+        // trying to log when JVM is failing will cause trouble but we can try to rollback
+        if (failure ne null) {
+          warn(s"Failed to commit active transaction on $conn. Trying to rollback.", failure)
+        }
+        rollbackSnapshotTx()
+      }
+    }
+  }
+
+  private def rollbackSnapshotTx(): Unit = {
+    ExternalStoreUtils.handleRollback(() => {
+      connectionType match {
+        case ConnectionType.Embedded =>
+          conn.rollback()
+          val lcc = conn.unwrap(classOf[EmbedConnection]).getLanguageConnectionContext
+          if (lcc ne null) {
+            lcc.clearExecuteLocally()
+          }
+        case _ => conn.rollback()
+      }
+    }, () => {
+      trace(s"Finished rollback of active transaction on $conn")
+    })
+  }
+
+  final def success(): Boolean = {
+    isSuccess
+  }
+
+  /**
+   * Apply `delayRollover` and `catalogVersion` attributes on the current context.
+   */
+  private def applyTransientAttributes(): Unit = {
+    connectionType match {
+      case ConnectionType.Embedded =>
+        if (delayRollover) {
+          GfxdSystemProcedures.setDelayRollover(
+            conn.unwrap(classOf[EmbedConnection]).getLanguageConnection, true)
+        }
+      case _ =>
+        conn.unwrap(classOf[ClientConnection]).updateCommonStatementAttributes(
+          new Consumer[StatementAttrs] {
+            override def accept(attrs: StatementAttrs): Unit = {
+              if (catalogVersion != -1) attrs.setCatalogVersion(catalogVersion)
+              else attrs.unsetCatalogVersion()
+              if (delayRollover) attrs.setDelayRollover(delayRollover)
+              else attrs.unsetDelayRollover()
+            }
+          })
+    }
+  }
+
+  final def setMetrics(compactionMetric: SQLMetric, rolloverMetric: SQLMetric): Unit = {
+    this.compactionMetric = Option(compactionMetric)
+    this.rolloverMetric = Option(rolloverMetric)
+  }
+
+  final def connection: Connection = {
+    if (isInitialized) return conn
+
+    // should only happen for rollover that should have an existing temporary connection
+    assert(connectionType == ConnectionType.Embedded)
+    val currentCM = ContextService.getFactory.getCurrentContextManager
+    if (currentCM ne null) {
+      conn = EmbedConnectionContext.getEmbedConnection(currentCM)
+    }
+    if (isInitialized) conn
+    else {
+      throw new IllegalStateException("Unexpected call to SnapshotConnectionListener.connection " +
+          "with empty TaskContext and no existing EmbedConnectionContext")
+    }
+  }
+}
+
+/**
+ * This companion class is primarily to ensure that only a single listener is attached in a
+ * TaskContext (e.g. delta buffer + column table scan, or putInto may try to attach twice).
+ */
+object SnapshotConnectionListener extends Logging {
+
+  private[this] val contextToListener =
+    new ConcurrentHashMap[TaskContext, SnapshotConnectionListener]()
+
+  // directly match successful CompactionResults so the count of matches will suffice
+  // private val parseCompactionResult =
+  //  "CompactionResult\\(ColumnKey\\([^)]*\\),[0-9]*,true\\)".r
+
+  // directly match non-zero numKeysRolledOver so the count of matches will suffice
+  private val parseRolloverResult =
+    "RolloverResult\\(numKeysRolledOver=0*[1-9][0-9]*,[^)]*\\)".r
+
+  private def taskContext(context: TaskContext): TaskContext =
+    if (context ne null) context else Utils.getTaskContext
+
+  def apply(context: TaskContext, externalStore: JDBCSourceAsColumnarStore, delayRollover: Boolean,
+      creator: Either[Long, () => (Connection, Long)]): SnapshotConnectionListener = {
+    apply(context, startSnapshotTx = true, externalStore.connectionType, externalStore.tableName,
+      Some(externalStore.tableName), externalStore.connProperties, delayRollover, creator)
+  }
+
+  def apply(context: TaskContext, startSnapshotTx: Boolean, connectionType: ConnectionType,
+      rowTable: String, lockDiskStore: Option[String],
+      connProps: ConnectionProperties, delayRollover: Boolean,
+      creator: Either[Long, () => (Connection, Long)]): SnapshotConnectionListener = {
+    // check for the temporary one in Utils too
+    val useContext = taskContext(context)
+    if (useContext ne null) {
+      // initialization of the listener is delayed to keep the computeIfAbsent method short
+      val taskListener = contextToListener.computeIfAbsent(useContext,
+        new Function[TaskContext, SnapshotConnectionListener] {
+          override def apply(context: TaskContext): SnapshotConnectionListener = {
+            val listener = new SnapshotConnectionListener(startSnapshotTx, connectionType,
+              rowTable, connProps, delayRollover, creator)
+            context.addTaskCompletionListener(listener)
+            context.addTaskFailureListener(listener)
+            listener
+          }
+        })
+      // there cannot be multiple threads accessing the same TaskContext so below is safe
+      if (taskListener.isInitialized) {
+        // existing listener may see change in attributes
+        if (startSnapshotTx && !taskListener.startSnapshotTx) {
+          trace(s"Enabling snapshot on a non-transactional pool for ${taskListener.connection}")
+          taskListener.startSnapshotTx = true
+          taskListener.delayRollover ||= delayRollover
+          taskListener.beginSnapshotTx()
+        }
+        if (delayRollover && !taskListener.delayRollover) {
+          trace(s"Changing delayRollover to true on ${taskListener.connection}")
+          taskListener.delayRollover = true
+          taskListener.applyTransientAttributes()
+        }
+      } else if (context ne null) { // skip initialization for temporary context
+        taskListener.initialize()
+      }
+      if (lockDiskStore.isDefined) taskListener.doLockDiskStore(lockDiskStore.get)
+      taskListener
+    } else {
+      throw new IllegalArgumentException("SnapshotConnectionListener: TaskContext was null")
+    }
+  }
+
+  def getExisting(context: TaskContext): Option[SnapshotConnectionListener] = {
+    val useContext = taskContext(context)
+    if (useContext ne null) Option(contextToListener.get(useContext)) else None
+  }
+
+  def trace(msg: => String): Unit = super.logDebug(msg)
+
+  def warn(msg: => String, throwable: Throwable): Unit = super.logWarning(msg, throwable)
+
+  private[sql] def clearContext(context: TaskContext, listener: SnapshotConnectionListener): Unit =
+    contextToListener.remove(context, listener)
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.sources.{DestroyRelation, JdbcExtendedUtils, NativeTableRowLevelSecurityRelation}
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types.{LongType, StructType}
@@ -102,12 +101,6 @@ trait TableExec extends UnaryExecNode with CodegenSupportOnExecutor {
               s"$partColumn in child output for $toString")))
       ClusteredDistribution(childPartitioningAttributes) :: Nil
     } else UnspecifiedDistribution :: Nil
-  }
-
-  override lazy val metrics: Map[String, SQLMetric] = {
-    if (onExecutor) Map.empty
-    else Map(s"num${opType}Rows" -> SQLMetrics.createMetric(sparkContext,
-      s"number of ${opType.toLowerCase} rows"))
   }
 
   override protected def doExecute(): RDD[InternalRow] = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
 import com.gemstone.gemfire.cache.EntryDestroyedException
-import com.gemstone.gemfire.internal.cache.{BucketRegion, LocalRegion, NonLocalRegionEntry, PartitionedRegion, RegionEntry, TXStateInterface, Token}
+import com.gemstone.gemfire.internal.cache.{BucketRegion, LocalRegion, NonLocalRegionEntry, PartitionedRegion, RegionEntry, TXManagerImpl, TXStateInterface, Token}
 import com.gemstone.gemfire.internal.shared.FetchRequest
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
 
@@ -50,7 +50,8 @@ object ColumnBatchIterator {
 class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
     bucketIds: java.util.Set[Integer], projection: Array[Int],
     fullScan: Boolean, context: TaskContext)
-    extends PRValuesIterator[ByteBuffer](container = null, region, bucketIds, context) {
+    extends PRValuesIterator[ByteBuffer](container = null, region, bucketIds, context,
+      TXManagerImpl.getCurrentTXState) {
 
   if (region ne null) {
     assert(!region.getEnableOffHeapMemory,
@@ -160,7 +161,7 @@ class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
     }
   }
 
-  private def releaseColumns(): Int = {
+  private final def releaseColumns(): Int = {
     val previousColumns = currentColumns
     if ((previousColumns ne null) && previousColumns.nonEmpty) {
       currentColumns = null

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
@@ -117,12 +117,6 @@ class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
     } else null
   }
 
-  final def fillColumnLobs(): Boolean = {
-    if (region ne null) {
-      itr.getBucketEntriesIterator.asInstanceOf[ClusteredColumnIterator].fillColumnValues()
-    } else true
-  }
-
   final def getColumnLob(columnIndex: Int): ByteBuffer = {
     if (region ne null) {
       getColumnBuffer(columnIndex + 1, throwIfMissing = true)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -19,22 +19,16 @@ package org.apache.spark.sql.execution.columnar
 import java.nio.ByteBuffer
 import java.sql.Connection
 
-import scala.util.control.NonFatal
-
-import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
-import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
-
-import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.SnapshotConnectionListener
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.sources.ConnectionProperties
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.{Logging, TaskContext}
 
 trait ExternalStore extends Serializable with Logging {
-
-  final val columnPrefix = "COL_"
 
   def tableName: String
 
@@ -42,101 +36,47 @@ trait ExternalStore extends Serializable with Logging {
 
   def storeColumnBatch(tableName: String, batch: ColumnBatch, partitionId: Int, batchId: Long,
       maxDeltaRows: Int, compressionCodecId: Int, changesToDeltaBuffer: SQLMetric,
-      numColumnBatches: SQLMetric, changesToColumnStore: SQLMetric, conn: Option[Connection]): Unit
+      numColumnBatches: SQLMetric, changesToColumnStore: SQLMetric,
+      listener: SnapshotConnectionListener): Unit
 
   def storeDelete(tableName: String, buffer: ByteBuffer, partitionId: Int,
-      batchId: Long, compressionCodecId: Int, conn: Option[Connection]): Unit
+      batchId: Long, compressionCodecId: Int, conn: Connection): Unit
 
   def getColumnBatchRDD(tableName: String, rowBuffer: String, projection: Array[Int],
       filters: Array[Expression], prunePartitions: () => Int, session: SparkSession,
       schema: StructType, delayRollover: Boolean): RDD[Any]
 
-  def getConnectedExternalStore(tableName: String,
-      onExecutor: Boolean): ConnectedExternalStore
-
-  def getConnection(id: String, onExecutor: Boolean): java.sql.Connection
+  def getExistingConnection(context: Option[TaskContext]): Option[Connection]
 
   def connProperties: ConnectionProperties
 
-  def tryExecute[T](tableName: String, closeOnSuccessOrFailure: Boolean = true,
-      onExecutor: Boolean = false)(f: Connection => T)
-      (implicit c: Option[Connection] = None): T = {
+  def tryExecute[T](tableName: String, onExecutor: Boolean = false)(f: Connection => T): T = {
     var success = false
-    val conn = c.getOrElse(getConnection(tableName, onExecutor))
+    val existing = getExistingConnection(context = None)
+    val conn = existing match {
+      case Some(c) => c
+      case None => ExternalStoreUtils.getConnection(
+        tableName, connProperties, onExecutor, resetIsolationLevel = true)
+    }
     try {
       val ret = f(conn)
       success = true
       ret
     } finally {
-      if (closeOnSuccessOrFailure && !conn.isInstanceOf[EmbedConnection] && !conn.isClosed) {
-        try {
-          if (success) conn.commit()
-          else handleRollback(conn.rollback)
-        } finally {
-          conn.close()
-        }
+      if (existing.isEmpty) {
+        commitOrRollback(success, conn)
       }
     }
   }
 
-  def handleRollback(rollback: () => Unit, finallyCode: () => Unit = null): Unit = {
-    try {
-      rollback()
-    } catch {
-      case NonFatal(e) =>
-        if (GemFireXDUtils.retryToBeDone(e)) logInfo(e.toString) else logWarning(e.toString, e)
-    } finally {
-      if (finallyCode ne null) finallyCode()
-    }
-  }
-}
-
-trait ConnectedExternalStore extends ExternalStore {
-
-  private[this] var dependentAction: Option[Connection => Unit] = None
-
-  protected[this] val connectedInstance: Connection
-
-  def conn: Connection = {
-    assert(!connectedInstance.isClosed)
-    connectedInstance
-  }
-
-  def commitAndClose(isSuccess: Boolean): Unit = {
-    // ideally shouldn't check for isClosed.it means some bug!
-    val conn = connectedInstance
-    if (!conn.isInstanceOf[EmbedConnection] && !conn.isClosed) {
+  def commitOrRollback(success: Boolean, conn: Connection): Unit = {
+    if (!conn.isClosed) {
       try {
-        if (isSuccess) {
-          conn.commit()
-        } else {
-          conn.rollback()
-        }
+        if (success) conn.commit()
+        else ExternalStoreUtils.handleRollback(conn.rollback)
       } finally {
         conn.close()
       }
     }
-  }
-
-  override def tryExecute[T](tableName: String,
-      closeOnSuccess: Boolean = true, onExecutor: Boolean = false)
-      (f: Connection => T)
-      (implicit c: Option[Connection]): T = {
-    assert(!connectedInstance.isClosed)
-    val ret = super.tryExecute(tableName,
-      closeOnSuccessOrFailure = false /* responsibility of the user to close later */ ,
-      onExecutor)(f)(Some(connectedInstance))
-
-    if (dependentAction.isDefined) {
-      assert(!connectedInstance.isClosed)
-      dependentAction.get(connectedInstance)
-    }
-
-    ret
-  }
-
-  def withDependentAction(f: Connection => Unit): ConnectedExternalStore = {
-    dependentAction = Some(f)
-    this
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ClusteredColumnIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ClusteredColumnIterator.scala
@@ -27,6 +27,11 @@ import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator
 abstract class ClusteredColumnIterator extends CloseableIterator[RegionEntry] {
 
   /**
+   * Fill values for all the projected columns and return true if successful else false.
+   */
+  def fillColumnValues(): Boolean
+
+  /**
    * Get the column value (1-based) for current iterator position. Requires
    * the hasNext and next of iterator to have been invoked first else can
    * throw an NullPointerException.

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ClusteredColumnIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ClusteredColumnIterator.scala
@@ -27,11 +27,6 @@ import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator
 abstract class ClusteredColumnIterator extends CloseableIterator[RegionEntry] {
 
   /**
-   * Fill values for all the projected columns and return true if successful else false.
-   */
-  def fillColumnValues(): Boolean
-
-  /**
    * Get the column value (1-based) for current iterator position. Requires
    * the hasNext and next of iterator to have been invoked first else can
    * throw an NullPointerException.

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnCompactor.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2017-2021 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.execution.columnar.impl
+
+import java.nio.ByteBuffer
+import java.util.function.BiFunction
+import java.util.{Collections, NoSuchElementException}
+
+import com.gemstone.gemfire.internal.cache.{BucketRegion, ExternalTableMetaData, LocalRegion, RegionEntry, TXManagerImpl, TXStateInterface}
+import com.gemstone.gemfire.internal.concurrent.ConcurrentHashSet
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
+import io.snappydata.Property.{ColumnCompactionRatio, SerializeWrites}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.collection.{LazyIterator, Utils}
+import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding
+import org.apache.spark.sql.execution.columnar.{ColumnBatchIterator, ColumnInsertExec, ColumnTableScan, ExternalStore, ExternalStoreUtils}
+import org.apache.spark.sql.execution.row.ResultSetTraversal
+import org.apache.spark.sql.execution.{BufferedRowIterator, WholeStageCodegenExec}
+import org.apache.spark.sql.store.CodeGeneration
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.{Logging, SparkEnv}
+
+/**
+ * Compact column batches, if required, and insert new compacted column batches,
+ * or if they are too small then push into row delta buffer.
+ */
+object ColumnCompactor extends Logging {
+
+  /**
+   * Track the keys being currently compacted to check for concurrent compactions.
+   * While the default as true for "snappydata.sql.serializeWrites" will prevent multiple
+   * concurrent operations, a single operation can have multiple tasks on the same bucket
+   * but should never have overlapping keys.
+   */
+  private[this] val compactionsInProgress = new ConcurrentHashSet[ColumnFormatKey]()
+
+  private[this] lazy val compactionRatio: Double = try {
+    SparkEnv.get match {
+      case null => System.getProperty(ColumnCompactionRatio.name,
+        ColumnCompactionRatio.defaultValue.get.toString).toDouble
+      case env => ColumnCompactionRatio.get(env.conf)
+    }
+  } catch {
+    case e: Exception =>
+      val sysProp = System.getProperty(ColumnCompactionRatio.name)
+      val msgPart =
+        if (sysProp ne null) s"as system property = $sysProp"
+        else "in spark configuration"
+      logError(s"Ignoring invalid value of ${ColumnCompactionRatio.name} $msgPart" +
+          s"(reverting to default of ${ColumnCompactionRatio.defaultValue.get}): ${e.getMessage}")
+      ColumnCompactionRatio.defaultValue.get
+  }
+
+  private def getSchema(metadata: ExternalTableMetaData): StructType = {
+    metadata.schema.asInstanceOf[StructType]
+  }
+
+  /**
+   * Check if compaction of a batch with given updated/deleted rows and total is required.
+   */
+  private[columnar] def isCompactionRequired(numDeltaRows: Int, numBatchRows: Int): Boolean = {
+    assert(numDeltaRows <= numBatchRows)
+    compactionRatio < 1.0 && compactionRatio * numBatchRows.toDouble <= numDeltaRows.toDouble
+  }
+
+  /**
+   * Returns Some(true) if all the rows in a batch have been deleted, Some(false) if the
+   * batch needs to be compacted, and None if neither.
+   */
+  private[columnar] def batchDeleteOrCompact(deleteBuffer: ByteBuffer): Option[Boolean] = {
+    val allocator = ColumnEncoding.getAllocator(deleteBuffer)
+    val bufferBytes = allocator.baseObject(deleteBuffer)
+    val bufferCursor = allocator.baseOffset(deleteBuffer) + 4
+    val numBaseRows = ColumnEncoding.readInt(bufferBytes, bufferCursor)
+    val numDeletes = ColumnEncoding.readInt(bufferBytes, bufferCursor + 4)
+    if (numDeletes >= numBaseRows) Some(true)
+    else if (isCompactionRequired(numDeletes, numBaseRows)) Some(false)
+    else None
+  }
+
+  /**
+   * Check if all the rows in a batch have been deleted.
+   */
+  private[columnar] def checkBatchDeleted(deleteBuffer: ByteBuffer): Boolean = {
+    batchDeleteOrCompact(deleteBuffer).contains(true)
+  }
+
+  def getValidTransaction(expectedRolloverDisabled: Boolean): Option[TXStateInterface] = {
+    // should only be invoked in the context of an active snapshot transaction,
+    // and rollover should be disabled else the reader might see the newly inserted batch too
+    val tx = TXManagerImpl.getCurrentTXState
+    if ((tx eq null) || !tx.isSnapshot || !tx.isInProgress) {
+      logError(s"ColumnCompactor: should only be invoked in the context of an " +
+          s"active SNAPSHOT transaction (current is $tx)")
+      None
+    } else if (expectedRolloverDisabled != tx.getProxy.isColumnRolloverDisabled) {
+      logError(s"ColumnCompactor: expected column rollover to be $expectedRolloverDisabled")
+      None
+    } else Option(tx)
+  }
+
+  /**
+   * Perform compaction of the batch with given key.
+   */
+  def compact(key: ColumnFormatKey, bucket: BucketRegion): Boolean = {
+    if (!bucket.getBucketAdvisor.isPrimary) return false
+
+    // check that cache should be open (assert will never fail rather the getter itself will)
+    assert(!Misc.getGemFireCache.isClosed)
+
+    // rollover would have been enabled when compaction is actually executed
+    val tx = getValidTransaction(expectedRolloverDisabled = false)
+    if (tx.isEmpty) return false
+
+    val statsKey = key.toStatsRowKey
+    // check that no other compaction on the key should be going on in parallel
+    if (!compactionsInProgress.add(statsKey)) {
+      logError(s"A concurrent compaction is running on bucket ${bucket.getFullPath} for batch " +
+          s"with $statsKey which can lead to loss of data. Is $SerializeWrites set to false?")
+      return false
+    }
+    try {
+      // compaction is just using ColumnTableScan to read and rows that are fed to ColumnInsertExec
+      // which will do the requited inserts then delete the old batch
+      val pr = bucket.getPartitionedRegion
+      val container = pr.getUserAttribute.asInstanceOf[GemFireContainer]
+      val metadata = container.fetchHiveMetaData(false)
+      val schema = getSchema(metadata)
+      val columnTableName = container.getQualifiedTableName
+      val tableName = Misc.getFullTableNameFromRegionPath(pr.getColocatedWithRegion.getFullPath)
+      logDebug(s"ColumnCompactor: compacting batch in bucket ${bucket.getFullPath} " +
+          s"having $statsKey in $tableName, transaction: ${tx.get}")
+      // we enable splitting into delta row buffer only for partitioned tables because the
+      // delta buffer puts can go to remote nodes for non-partitioned tables breaking
+      // per-partition snapshot isolation that can cause scans to temporarily see duplicates
+      val maxDeltaRows = {
+        if (metadata.partitioningColumns.length == 0) -1 else metadata.columnMaxDeltaRows
+      }
+      Utils.withThreadLocalTransactionForBucket(bucket.getId, pr, { _ =>
+        Utils.withTempTaskContextIfAbsent {
+          val gen = CodeGeneration.compileCode(
+            CodeGeneration.compactKey(tableName), schema.fields, () => {
+              val schemaAttrs = schema.toAttributes
+              val tableScan = ColumnTableScan(schemaAttrs, dataRDD = null,
+                otherRDDs = Nil, numBuckets = -1,
+                partitionColumns = Nil, partitionColumnAliases = Nil,
+                baseRelation = null, schema, allFilters = Nil, schemaAttrs,
+                caseSensitive = true)
+              // using isPartitioned=true so that the bucketId set in iter.init() takes effect
+              val insertPlan = ColumnInsertExec(tableScan, Nil, Nil,
+                numBuckets = -1, isPartitioned = true, None,
+                (-metadata.columnBatchSize, maxDeltaRows, metadata.compressionCodec),
+                columnTableName, onExecutor = true, schema,
+                metadata.externalStore.asInstanceOf[ExternalStore], useMemberVariables = false)
+              // now generate the code with the help of WholeStageCodegenExec
+              // this is only used for local code generation while its RDD
+              // semantics and related methods are all ignored
+              val (ctx, code) = ExternalStoreUtils.codeGenOnExecutor(
+                WholeStageCodegenExec(insertPlan), insertPlan)
+              (code, ctx.references.toArray)
+            })
+          val iter = gen._1.generate(gen._2).asInstanceOf[BufferedRowIterator]
+
+          // create an iterator for the single batch and pass to generated code
+          iter.init(bucket.getId, Array(Iterator[Any](new LazyIterator(() =>
+            new ResultSetTraversal(conn = null, stmt = null, rs = null, context = null,
+              java.util.Collections.emptySet[Integer]())), new SingleColumnBatchIterator(
+            statsKey, bucket)).asInstanceOf[Iterator[InternalRow]]))
+          // if the insert count is zero (e.g. due to bucket just moved away) then don't delete
+          // ignore the result which is the insert count
+          var count = 0L
+          while (iter.hasNext) {
+            count += iter.next().getLong(0)
+          }
+          if (count > 0) {
+            ColumnDelta.deleteBatch(statsKey, pr, schema.length)
+            logDebug(s"ColumnCompactor: successfully compacted in bucket ${bucket.getFullPath} " +
+                s"and deleted batch with $statsKey in $tableName")
+          } else if (!bucket.getBucketAdvisor.isPrimary) {
+            logWarning(s"ColumnCompactor: primary bucket ${bucket.getFullPath} moved " +
+                s"for batch with $statsKey in $tableName")
+          } else {
+            logError(s"ColumnCompactor: missing batch in bucket ${bucket.getFullPath} " +
+                s"for compaction of batch with $statsKey in $tableName")
+          }
+          count > 0
+        }
+      })
+    } finally {
+      compactionsInProgress.remove(statsKey)
+    }
+  }
+}
+
+/**
+ * Provides a ColumnBatchIterator over a single column batch for [[ColumnTableScan]].
+ */
+final class SingleColumnBatchIterator(statsKey: ColumnFormatKey, bucket: BucketRegion)
+    extends ColumnBatchIterator(bucket, batch = null, Collections.singleton(bucket.getId),
+      Array.emptyIntArray, fullScan = true, context = null) {
+
+  override protected def createIterator(container: GemFireContainer, region: LocalRegion,
+      tx: TXStateInterface): PRIterator = {
+    val txState = if (tx ne null) tx.getLocalTXState else null
+    val createIterator = new BiFunction[BucketRegion, java.lang.Long,
+        java.util.Iterator[RegionEntry]] {
+      override def apply(br: BucketRegion,
+          numEntries: java.lang.Long): java.util.Iterator[RegionEntry] = {
+        new ClusteredColumnIterator {
+          private[this] var _hasNext = true
+
+          override def hasNext: Boolean = _hasNext
+
+          override def next(): RegionEntry = {
+            if (_hasNext) {
+              _hasNext = false
+              br.getRegionEntry(statsKey)
+            } else throw new NoSuchElementException
+          }
+
+          override def getColumnValue(column: Int): AnyRef =
+            br.get(statsKey.withColumnIndex(column), null)
+
+          override def close(): Unit = {}
+        }
+      }
+    }
+    val createRemoteIterator = new BiFunction[java.lang.Integer, PRIterator,
+        java.util.Iterator[RegionEntry]] {
+      override def apply(bucketId: Integer,
+          iter: PRIterator): java.util.Iterator[RegionEntry] = {
+        Collections.emptyIterator[RegionEntry]()
+      }
+    }
+    val pr = bucket.getPartitionedRegion
+    new pr.PRLocalScanIterator(getBucketSet, txState, createIterator, createRemoteIterator,
+      false, true, false)
+  }
+}
+
+/**
+ * Result of compaction of a column batch added to transaction pre-commit results.
+ *
+ * NOTE: if the layout of this class or ColumnFormatKey changes, then update the regex pattern in
+ * SnapshotConnectionListener.parseCompactionResult that parses the toString() of this class
+ */
+case class CompactionResult(batchKey: ColumnFormatKey, bucketId: Int, success: Boolean)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnCompactor.scala
@@ -118,6 +118,10 @@ object ColumnCompactor extends Logging {
 
   /**
    * Perform compaction of the batch with given key.
+   *
+   * TODO: PERF: for delta compaction, merge and replace required columns only using
+   * ColumnDeltaEncoder.merge rather than creating an entire new batch for best performance.
+   * Also update the stats row for those columns.
    */
   def compact(key: ColumnFormatKey, bucket: BucketRegion): Boolean = {
     if (!bucket.getBucketAdvisor.isPrimary) return false

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatIterator.scala
@@ -167,6 +167,9 @@ final class ColumnFormatIterator(baseRegion: LocalRegion, projection: Array[Int]
     }
   }
 
+  // don't expect any missing values with local snapshot isolation
+  override def fillColumnValues(): Boolean = true
+
   override def getColumnValue(columnIndex: Int): AnyRef = {
     val column = columnIndex & 0xffffffffL
     if (entryIterator ne null) inMemoryBatches.get(inMemoryBatchIndex).get(column)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatIterator.scala
@@ -167,9 +167,6 @@ final class ColumnFormatIterator(baseRegion: LocalRegion, projection: Array[Int]
     }
   }
 
-  // don't expect any missing values with local snapshot isolation
-  override def fillColumnValues(): Boolean = true
-
   override def getColumnValue(columnIndex: Int): AnyRef = {
     val column = columnIndex & 0xffffffffL
     if (entryIterator ne null) inMemoryBatches.get(inMemoryBatchIndex).get(column)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -132,7 +132,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
           ColumnFormatEntry.DELETE_MASK_COL_INDEX)
 
         // check for full batch delete
-        if (ColumnDelta.checkBatchDeleted(buffer)) {
+        if (ColumnCompactor.checkBatchDeleted(buffer)) {
           ColumnDelta.deleteBatch(key, region, key.getNumColumnsInTable(columnTableName))
           return
         }
@@ -140,7 +140,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
 
       case _ =>
         // check for full batch delete
-        if (ColumnDelta.checkBatchDeleted(buffer)) {
+        if (ColumnCompactor.checkBatchDeleted(buffer)) {
           val deleteStr = s"delete from ${quotedName(columnTableName)} where " +
               "uuid = ? and partitionId = ? and columnIndex = ?"
           val stmt = connection.prepareStatement(deleteStr)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -288,12 +288,13 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             // first check the full stats
             val statsRow = SharedUtils.toUnsafeRow(batchIterator.currentVal, numColumnsInStatBlob)
             // skip filtering if old format delta stats row containing obsolete data is present
-            if ((batchIterator.getCurrentDeltaStats ne null) || filterPredicate.check(statsRow)) {
+            if (((batchIterator.getCurrentDeltaStats ne null) || filterPredicate.check(statsRow))
+                && batchIterator.fillColumnLobs()) {
               return
             }
             batchIterator.moveNext()
           }
-          else return
+          else if (batchIterator.fillColumnLobs()) return
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -25,20 +25,18 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import com.gemstone.gemfire.cache.{EntryDestroyedException, RegionDestroyedException}
+import com.gemstone.gemfire.cache.RegionDestroyedException
 import com.gemstone.gemfire.internal.cache.lru.LRUEntry
 import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator
-import com.gemstone.gemfire.internal.cache.{BucketRegion, EntryEventImpl, ExternalTableMetaData, LocalRegion, TXManagerImpl, TXStateInterface}
+import com.gemstone.gemfire.internal.cache.{BucketRegion, EntryEventImpl, ExternalTableMetaData, LocalRegion}
 import com.gemstone.gemfire.internal.shared.{FetchRequest, SystemProperties}
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats
 import com.gemstone.gemfire.internal.snappy.{CallbackFactoryProvider, ColumnTableEntry, StoreCallbacks, UMMMemoryTracker}
 import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.engine.access.GemFireTransaction
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.{AbstractCompactExecRow, GemFireContainer}
 import com.pivotal.gemfirexd.internal.engine.ui.SnappyRegionStats
 import com.pivotal.gemfirexd.internal.iapi.error.{PublicAPI, StandardException}
-import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
 import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.iapi.util.IdUtil
 import com.pivotal.gemfirexd.internal.impl.jdbc.{EmbedConnection, Util}
@@ -79,34 +77,9 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
     val catalogEntry: ExternalTableMetaData = container.fetchHiveMetaData(false)
 
     if (catalogEntry != null) {
-      // LCC should be available assuming insert is already being done
-      // via a proper connection
-      var conn: EmbedConnection = null
-      var contextSet: Boolean = false
-      var txStateSet: Boolean = false
-      try {
-        var lcc: LanguageConnectionContext = Misc.getLanguageConnectionContext
-        if (lcc == null) {
-          conn = GemFireXDUtils.getTSSConnection(true, true, false)
-          conn.getTR.setupContextStack()
-          contextSet = true
-          lcc = conn.getLanguageConnectionContext
-          if (lcc == null) {
-            Misc.getGemFireCache.getCancelCriterion.checkCancelInProgress(null)
-            throw StandardException.newException(SQLState.NO_CURRENT_CONNECTION)
-          }
-          if (conn.getAutoCommit) conn.setAutoCommit(false, true)
-        }
-        val row: AbstractCompactExecRow = container.newTemplateRow()
-            .asInstanceOf[AbstractCompactExecRow]
-        val tc = lcc.getTransactionExecute.asInstanceOf[GemFireTransaction]
-        lcc.setExecuteLocally(Collections.singleton(bucketID), pr, false, null)
-        try {
-          val state: TXStateInterface = TXManagerImpl.getCurrentTXState
-          if (tc.getCurrentTXStateProxy == null && state != null) {
-            tc.setActiveTXState(state, true)
-            txStateSet = true
-          }
+      Utils.withThreadLocalTransactionForBucket(bucketID, pr, {
+        lcc =>
+          val row = container.newTemplateRow().asInstanceOf[AbstractCompactExecRow]
           val sc = lcc.getTransactionExecute.openScan(
             container.getId.getContainerId, false, 0,
             TransactionController.MODE_RECORD,
@@ -141,15 +114,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             catalogEntry.externalStore.asInstanceOf[ExternalStore],
             catalogEntry.compressionCodec)
           batchCreator.createAndStoreBatch(sc, row, bucketID, indexes)
-        } finally {
-          lcc.clearExecuteLocally()
-          if (txStateSet) tc.clearActiveTXState(false, true)
-        }
-      } finally {
-        if (contextSet) {
-          conn.getTR.restoreContextStack()
-        }
-      }
+      })
     } else {
       Collections.emptySet[AnyRef]()
     }
@@ -288,13 +253,12 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             // first check the full stats
             val statsRow = SharedUtils.toUnsafeRow(batchIterator.currentVal, numColumnsInStatBlob)
             // skip filtering if old format delta stats row containing obsolete data is present
-            if (((batchIterator.getCurrentDeltaStats ne null) || filterPredicate.check(statsRow))
-                && batchIterator.fillColumnLobs()) {
+            if ((batchIterator.getCurrentDeltaStats ne null) || filterPredicate.check(statsRow)) {
               return
             }
             batchIterator.moveNext()
           }
-          else if (batchIterator.fillColumnLobs()) return
+          else return
         }
       }
 
@@ -345,10 +309,10 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
         }
         if (throwIfMissing) {
           // empty buffer indicates value removed from region
-          val ede = new EntryDestroyedException(s"Iteration on column=$columnPosition " +
-              s"partition=$bucketId batchUUID=$uuid failed due to missing value")
-          throw PublicAPI.wrapStandardException(StandardException.newException(
-            SQLState.DATA_UNEXPECTED_EXCEPTION, ede))
+          val msg = s"Iteration on column=$columnPosition " +
+              s"partition=$bucketId batchUUID=$uuid failed due to missing value in"
+          throw PublicAPI.wrapStandardException(StandardException.newException(SQLState
+              .LANG_OBJECT_NOT_FOUND, msg, GemFireContainer.getRowBufferTableName(columnTable)))
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
@@ -31,7 +31,7 @@ case class RowInsertExec(child: SparkPlan, putInto: Boolean,
     relation: Option[DestroyRelation], onExecutor: Boolean, resolvedName: String,
     connProps: ConnectionProperties) extends RowExec {
 
-  override def opType: String = if (putInto) "Put" else "Inserted"
+  override def opType: String = if (putInto) "Put" else "Insert"
 
   override protected def isInsert: Boolean = true
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -107,7 +107,7 @@ case class ExternalTableDMLCmd(
         Seq(Row(relation.executeUpdate(command,
           JdbcExtendedUtils.toUpperCase(session.catalog.currentDatabase))))
       case other => throw new AnalysisException("DML support requires " +
-          "SingleRowInsertableRelation but found " + other)
+          "NativeTableRelation but found " + other)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
@@ -53,10 +53,6 @@ import org.apache.spark.{Logging, SparkEnv}
  */
 object CodeGeneration extends Logging {
 
-  override def logInfo(msg: => String): Unit = super.logInfo(msg)
-
-  override def logDebug(msg: => String): Unit = super.logDebug(msg)
-
   lazy val (codeCacheSize, cacheSize) = {
     val env = SparkEnv.get
     val size = if (env ne null) {

--- a/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
+++ b/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
@@ -29,8 +29,6 @@ class CommandLineToolsSuite extends SnappyTestRunner {
 
   override def servers: String = s"$localHostName\n"
 
-  override def clusterSuccessString: String = "Distributed system now has 3 members"
-
   private val snappyProductDir = System.getProperty("SNAPPY_HOME")
   private val snappyNativeTestDir = s"$snappyProductDir/../../../store/native/tests"
 
@@ -224,7 +222,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
       stmnt.execute("drop table if exists tmptable")
     }
   }
-      
+
   // scalastyle:off println
   test("backup restore") {
     val debugWriter = new PrintWriter(s"$snappyHome/CommandLineToolsSuite.debug")

--- a/docs/reference/interactive_commands/show.md
+++ b/docs/reference/interactive_commands/show.md
@@ -76,7 +76,6 @@ SYS                 |GET_EVICTION_HEAP_PERCENTAGE  |com.pivotal.gemfire&
 SYS                 |GET_EVICTION_OFFHEAP_PERCENTA&|com.pivotal.gemfire&
 SYS                 |GET_IS_NATIVE_NANOTIMER       |com.pivotal.gemfire&
 SYS                 |GET_NATIVE_NANOTIMER_TYPE     |com.pivotal.gemfire&
-SYS                 |GET_SNAPSHOT_TXID_AND_HOSTURL |com.pivotal.gemfire&
 SYS                 |GET_TABLE_VERSION             |com.pivotal.gemfire&
 SYS                 |HDFS_LAST_MAJOR_COMPACTION    |com.pivotal.gemfire&
 SYSCS_UTIL          |CHECK_TABLE                   |com.pivotal.gemfire&

--- a/encoders/src/main/scala/org/apache/spark/sql/collection/SharedUtils.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/collection/SharedUtils.scala
@@ -29,13 +29,13 @@ import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker
 
-import org.apache.spark._
 import org.apache.spark.memory.{MemoryManagerCallback, MemoryMode, TaskMemoryManager}
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.MutableURLClassLoader
+import org.apache.spark.{Partition, TaskContext}
 
-object SharedUtils extends Logging {
+object SharedUtils {
 
   final val EMPTY_STRING_ARRAY = Array.empty[String]
 
@@ -117,14 +117,6 @@ object SharedUtils extends Logging {
     os.close()
     filters
   }
-
-  override def logDebug(msg: => String): Unit = super.logInfo(msg)
-
-  override def logInfo(msg: => String): Unit = super.logInfo(msg)
-
-  override def logWarning(msg: => String): Unit = super.logWarning(msg)
-
-  override def logError(msg: => String): Unit = super.logError(msg)
 }
 
 final class SmartExecutorBucketPartition(private var _index: Int, private var _bucketId: Int,

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -149,6 +149,9 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
     buffer
   }
 
+  // skipping for partial data is taken care of by StoreCallbacksImpl.columnTableScan
+  def fillColumnLobs(): Boolean = true
+
   def getColumnLob(columnIndex: Int): ByteBuffer = {
     val buffer = colBuffers.get(columnIndex + 1)
     if (buffer ne null) buffer

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -149,9 +149,6 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
     buffer
   }
 
-  // skipping for partial data is taken care of by StoreCallbacksImpl.columnTableScan
-  def fillColumnLobs(): Boolean = true
-
   def getColumnLob(columnIndex: Int): ByteBuffer = {
     val buffer = colBuffers.get(columnIndex + 1)
     if (buffer ne null) buffer

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.execution.columnar.encoding
 import java.nio.{ByteBuffer, ByteOrder}
 
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
-import com.gemstone.gemfire.internal.shared.unsafe.DirectBufferAllocator
-import com.gemstone.gemfire.internal.shared.{BufferAllocator, ClientSharedUtils, HeapBufferAllocator}
+import com.gemstone.gemfire.internal.shared.{BufferAllocator, ClientSharedUtils}
 import io.snappydata.util.StringUtils
 
 import org.apache.spark.memory.MemoryManagerCallback.memoryManager
@@ -780,9 +779,8 @@ object ColumnEncoding {
     }
   }
 
-  def getAllocator(buffer: ByteBuffer): BufferAllocator =
-    if (buffer.isDirect) DirectBufferAllocator.instance()
-    else HeapBufferAllocator.instance()
+  @inline
+  def getAllocator(buffer: ByteBuffer): BufferAllocator = BufferAllocator.of(buffer)
 
   def getColumnDecoder(buffer: ByteBuffer, field: StructField): ColumnDecoder =
     getColumnDecoder(buffer, field, ColumnEncoding.identityLong)

--- a/jdbc/src/main/scala/org/apache/spark/Logging.scala
+++ b/jdbc/src/main/scala/org/apache/spark/Logging.scala
@@ -55,7 +55,7 @@ trait Logging {
     if (value) levelFlags |= enabled else levelFlags |= disabled
   }
 
-  protected final def isInfoEnabled: Boolean = {
+  final def isInfoEnabled: Boolean = {
     val levelFlags = this.levelFlags
     if ((levelFlags & Logging.INFO_ENABLED) != 0) true
     else if ((levelFlags & Logging.INFO_DISABLED) != 0) false
@@ -66,7 +66,7 @@ trait Logging {
     }
   }
 
-  protected final def isDebugEnabled: Boolean = {
+  final def isDebugEnabled: Boolean = {
     val levelFlags = this.levelFlags
     if ((levelFlags & Logging.DEBUG_DISABLED) != 0) false
     else if ((levelFlags & Logging.DEBUG_ENABLED) != 0) true
@@ -77,7 +77,7 @@ trait Logging {
     }
   }
 
-  protected final def isTraceEnabled: Boolean = {
+  final def isTraceEnabled: Boolean = {
     val levelFlags = this.levelFlags
     if ((levelFlags & Logging.TRACE_DISABLED) != 0) false
     else if ((levelFlags & Logging.TRACE_ENABLED) != 0) true
@@ -89,44 +89,44 @@ trait Logging {
   }
 
   // Log methods that take only a String
-  protected def logInfo(msg: => String) {
+  def logInfo(msg: => String): Unit = {
     if (isInfoEnabled) log.info(msg)
   }
 
-  protected def logDebug(msg: => String) {
+  def logDebug(msg: => String): Unit = {
     if (isDebugEnabled) log.debug(msg)
   }
 
-  protected def logTrace(msg: => String) {
+  def logTrace(msg: => String): Unit = {
     if (isTraceEnabled) log.trace(msg)
   }
 
-  protected def logWarning(msg: => String) {
+  def logWarning(msg: => String): Unit = {
     if (log.isWarnEnabled) log.warn(msg)
   }
 
-  protected def logError(msg: => String) {
+  def logError(msg: => String): Unit = {
     if (log.isErrorEnabled) log.error(msg)
   }
 
   // Log methods that take Throwables (Exceptions/Errors) too
-  protected def logInfo(msg: => String, throwable: Throwable) {
+  def logInfo(msg: => String, throwable: Throwable): Unit = {
     if (isInfoEnabled) log.info(msg, throwable)
   }
 
-  protected def logDebug(msg: => String, throwable: Throwable) {
+  def logDebug(msg: => String, throwable: Throwable): Unit = {
     if (isDebugEnabled) log.debug(msg, throwable)
   }
 
-  protected def logTrace(msg: => String, throwable: Throwable) {
+  def logTrace(msg: => String, throwable: Throwable): Unit = {
     if (isTraceEnabled) log.trace(msg, throwable)
   }
 
-  protected def logWarning(msg: => String, throwable: Throwable) {
+  def logWarning(msg: => String, throwable: Throwable): Unit = {
     if (log.isWarnEnabled) log.warn(msg, throwable)
   }
 
-  protected def logError(msg: => String, throwable: Throwable) {
+  def logError(msg: => String, throwable: Throwable): Unit = {
     if (log.isErrorEnabled) log.error(msg, throwable)
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

 Cleanup to use a common SnapshotConnectionListener for handle snapshot transactions

- use a single SnapshotConnectionListener for every TaskContext (maintained in a map)
  and thus have a single connection shared among all the plans in a single Task
- removed all other custom TaskCompletionListeners that handle connection close/commit etc
- removed all code to explicitly start snapshot transactions, obtain TXID, transfer to
  connections etc since everything is now handled by the common SnapshotConnectionListener
  having a single shared connection
- maintain separate snapshot-enabled and disabled pools where the latter can temporarily
  have snapshot transactions running on them (due to row table being joined with column
      table, for example) whose isolation level is explicitly reverted at the end
- use a temporary TaskContext for cases where it is not available in ColumnBatchIterator
  to enable using the common SnapshotConnectionListener consistently
- added metrics for number of column batches compacted and rolled over in update/delete
  plans which are handled using before-commit results in SnapshotConnectionListener
- added more metrics like number of deleted/updated batches to delete/update
- removed custom transaction handling in ColumnInsertExec and instead everything is now
  taken care of by SnapshotConnectionListener like for other plans
- added test that does concurrent updates/deletes/selects which will lead to continuous
  compactions and rollovers (code for former will be added in the following checkins);
  fixed multiple causes for failures in this new test (common SnapshotConnectionListener
      itself being the major fix)
- updated tests for the above changes
- updated tomcat-jdbc to latest version 10.0.10

- force start transaction immediately (instead of on first TX related operation) in
  SnapshotConnectionListener since the thread-local TX is used by PRValuesIterator
  in its contructor to create transactional local/remote iterators
- added a ClusteredColumnIterator.fillColumnValues() method to pre-fill all the projected
  columns instead of doing on first getColumnValue() call; this method returns a boolean
  to indicate whether all column values were found or not; now used by ColumnTableScan
  and its caller in StoreCallbacksImpl to skip a batch if any of the column values are missing
  (due to concurrent deletes/updates) instead of throwing an EntryNotFoundException later
- added cleanup of any remaining statsRows for case of premature RemoteEntriesIterator.close()
- made logging methods in Logging as public rather than protected

 batch compaction

- added batch compaction which is done when a batch has large number of deletes/updates
  as a before-commit action
- the new Spark-level property snappydata.column.compactionRatio (default is 0.1 i.e. 10%)
  determines at what point compaction will be triggered
- results of the compaction are captured by SnapshotConnectionListener and compaction
  metric of update/delete operation is incremented if set
- split out the code to use thread-local connection from StoreCallbacksImpl to Utils
  which is now used by compactor too
- if SnapshotConnectionListener picks up an EmbedConnection from current context, then
  don't close or commit/rollback it since that will be taken care of by the origin
  of the operation (which should be a remote node)
- removed the fillColumnLobs/fillColumnValues methods added in the iterator previously
  and their calls in ColumnTableScan since it is safer to throw an EntryDestroyException
  to let the task (and be retries) fail rather than silently skipping the batch
- removed the TaskCompletionListener to close encoders in ColumnInsertExec since they
  will hold references to the created batches which can build up if a large number of
  compactions get created in a single Task, so moved it to a finally block in generated code

## Patch testing

precheckin -Pstore; transactional hydra tests

## ReleaseNotes.txt changes

Release 1.3.0: added column compaction when number of updates/deletes exceed the limit specified by spark property snappydata.column.compactionRatio (default is 0.1)

## Other PRs 

https://github.com/TIBCOSoftware/snappy-store/pull/569
